### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,15 @@
     "homepage": "https://github.com/envant/fireable",
     "keywords": ["Laravel", "Fireable", "event"],
     "require": {
+        "php": "^7.1.3",
         "illuminate/support": "^5.8|^6",
         "illuminate/database": "^5.8|^6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
-        "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3.0",
-        "sempro/phpunit-pretty-print": "^1.0"
+        "phpunit/phpunit": "^7.5 || ^8.0",
+        "mockery/mockery": "^1.2",
+        "orchestra/testbench": "^3.8 || ^4.0",
+        "sempro/phpunit-pretty-print": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,7 +54,7 @@ abstract class TestCase extends BaseTestCase
     {
         $this->loadMigrationsFrom([
             '--database' => 'testbench',
-            '--realpath' => realpath(__DIR__.'/migrations'),
+            '--path' => realpath(__DIR__.'/migrations'),
         ]);
 
         $this->testUser = User::create([


### PR DESCRIPTION
This **PR** will:
​
- update version constraints in **composer.json** file:
    - Add **PHP** minimum version ( Laravel 5.8 requires PHP +7.1.3 )
    - Bump version dependencies;
    - Update **phpunit/phpunit**: "**^7.5|^8.0**"
    - Update **orchestra/testbench** - version compatibility:
    

Laravel | Testbench
-- | --
5.8.x | 3.8.x
6.x | 4.x

- Update `--realpath` to `--path` flag in **TestCase.php** file
