### PR TITLE
Update phpunit.xml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/temp
 .idea
 .phpunit.result.cache
 .DS_Store
+.phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,8 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter">
     <testsuites>
         <testsuite name="Package">
             <directory suffix=".php">./tests/</directory>


### PR DESCRIPTION
This **PR** will:

- Rename **phpunit.xml** to **phpunit.xml.dist**:
  - This way we allow developers to keep a custom phpunit.xml file locally if they want to. This is quite common in PHP packages.
- Add `printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter"` in phpunit file:
  - This will enable the **sempro/phpunit-pretty-print** package that is installed and **not** being used.
   - See:  ![phpunit-pretty-print](https://user-images.githubusercontent.com/6556083/66012116-2e0ac680-e49c-11e9-8bd8-8482912f1b15.png)

