### PR TITLE
Added GitHub Actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,4 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinter' tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,5 +35,7 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+      - name: PHP Version
+        run: php -v
       - name: Execute tests
         run: php vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinter' tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
+        laravel: [^8.74, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: 6.*
+          - laravel: ^8.74
+            testbench: ^6.4
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.74.*
-            testbench: ^6.4
+            testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.74.*
-            testbench: 6.4.*
+            testbench: ^6.4
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,9 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
+        laravel: [6.*, 7.*, 8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 7.*
+            testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,8 @@ jobs:
         laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.74.*
-            testbench: 6.*
+          - laravel: ^8.74
+            testbench: ^6.4
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,8 @@ jobs:
         laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^8.74
-            testbench: ^6.4
+          - laravel: 8.*
+            testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,4 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
       - name: Execute tests
-        run: vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinter' tests/
+        run: php vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinter' tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1]
-        laravel: [6.*, 7.*, 8.*, 9.*]
+        laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 6.*
-            testbench: 4.*
-          - laravel: 7.*
-            testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,5 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-      - name: PHP Version
-        run: php -v
       - name: Execute tests
         run: php vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinterForPhpUnit9' tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,8 @@ jobs:
         laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: 6.*
+          - laravel: 8.74.*
+            testbench: 6.4.*
           - laravel: 9.*
             testbench: 7.*
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,39 @@
+name: tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}, ${{ matrix.dependency-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 8.1]
+        laravel: [8.*, 9.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 9.*
+            testbench: 7.*
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+      - name: Install Dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,4 +42,4 @@ jobs:
       - name: PHP Version
         run: php -v
       - name: Execute tests
-        run: php vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinter' tests/
+        run: php vendor/bin/phpunit --printer 'Sempro\PHPUnitPrettyPrinter\PrettyPrinterForPhpUnit9' tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,22 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1]
-        laravel: [^8.74, 9.*]
+        laravel: [6.*, 7.*, ^8.74, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 7.*
+            testbench: 5.*
           - laravel: ^8.74
             testbench: ^6.4
           - laravel: 9.*
             testbench: 7.*
+#        exclude:
+#          - php: 8.1
+#            laravel: 6.*
+#          - php: 8.1
+#            laravel: 7.*
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       - name: PHP Version
         run: php -v
       - name: Execute tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,22 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1]
-        laravel: [6.*, 7.*, ^8.74, 9.*]
+        laravel: [^8.74, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 6.*
-            testbench: 4.*
-          - laravel: 7.*
-            testbench: 5.*
           - laravel: ^8.74
             testbench: ^6.4
           - laravel: 9.*
             testbench: 7.*
-#        exclude:
-#          - php: 8.1
-#            laravel: 6.*
-#          - php: 8.1
-#            laravel: 7.*
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^4 || ^5 || ^6.6 || ^7",
+        "orchestra/testbench": "^4 || ^5 || ^6.4 || ^7",
         "sempro/phpunit-pretty-print": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
+        "orchestra/testbench": "^4 || ^5 || ^6.6.2 || ^7",
         "sempro/phpunit-pretty-print": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^4 || ^5 || ^6.6.2 || ^7",
+        "orchestra/testbench": "^4 || ^5 || ^6.6 || ^7",
         "sempro/phpunit-pretty-print": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "keywords": ["Laravel", "Fireable", "event"],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^6|^7|^8|^9",
-        "illuminate/database": "^6|^7|^8|^9"
+        "illuminate/support": "^6 || ^7 || ^8 || ^9",
+        "illuminate/database": "^6 || ^7 || ^8 || ^9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
         "sempro/phpunit-pretty-print": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/database": "^6 || ^7 || ^8.74 || ^9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.14",
+        "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
         "sempro/phpunit-pretty-print": "^1.4"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/envant/fireable",
     "keywords": ["Laravel", "Fireable", "event"],
     "require": {
-        "php": "^8",
+        "php": "^8.0",
         "illuminate/support": "^6|^7|^8|^9",
         "illuminate/database": "^6|^7|^8|^9"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/database": "^6 || ^7 || ^8 || ^9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5.14",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
         "sempro/phpunit-pretty-print": "^1.4"

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     "homepage": "https://github.com/envant/fireable",
     "keywords": ["Laravel", "Fireable", "event"],
     "require": {
-        "php": "^7.2|^8",
-        "illuminate/support": "^5.8|^6|^7|^8|^9",
-        "illuminate/database": "^5.8|^6|^7|^8|^9"
+        "php": "^8",
+        "illuminate/support": "^6|^7|^8|^9",
+        "illuminate/database": "^6|^7|^8|^9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8 || ^9.5",
+        "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^3.8 || ^4 || ^5 || ^6 || ^7",
+        "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
         "sempro/phpunit-pretty-print": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "keywords": ["Laravel", "Fireable", "event"],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^6 || ^7 || ^8 || ^9",
-        "illuminate/database": "^6 || ^7 || ^8 || ^9"
+        "illuminate/support": "^6 || ^7 || ^8.74 || ^9",
+        "illuminate/database": "^6 || ^7 || ^8.74 || ^9"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.14",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpunit/phpunit": "^9.5.10",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4 || ^5 || ^6 || ^7",
-        "sempro/phpunit-pretty-print": "^1.1"
+        "sempro/phpunit-pretty-print": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -9,15 +10,16 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter">
+         printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory>src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Package">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
**Why did I hardcoded Laravel ^8.74?**
Because at "prefer-lowest" we get an error:

```
PHP Fatal error:  During inheritance of IteratorAggregate: Uncaught ErrorException: Return type of Symfony\Component\HttpFoundation\ParameterBag::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/fireable/fireable/vendor/symfony/http-foundation/ParameterBag.php:191
```

This is due to the fact that Laravel uses `"symfony/http-foundation": "^5.1.4"` before version `^8.74` in which there is no `#[\ReturnTypeWillChange]:` https://github.com/symfony/http-foundation/blob/5.1/ParameterBag.php#L205 but in 5.4 it already exists https://github.com/symfony/http-foundation/blob/5.4/ParameterBag.php#L212


**Why did I hardcoded `"orchestra/testbench": "^6.4"`?**
Because at "prefer-lowest" we get an error:

```
1) Envant\Fireable\Tests\FireableAttributesTest::testSetAnyValue
Error: Call to undefined method Envant\Fireable\Tests\FireableAttributesTest::getAnnotations()
```

To fix this, it was necessary to upgrade to newer versions. Since version `"orchestra/testbench": "^6.4"` this bug has been fixed.

**I also removed support PHP 7.2**